### PR TITLE
Improve upload workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,16 +14,20 @@
   </div>
   <p id="msg" class="text-gray-500 italic">Waiting for upload...</p>
   <script>
-    fetch("/tunnel.txt")
-      .then(r => r.text())
-      .then(txt => {
+    async function loadQR() {
+      try {
+        const txt = await fetch('/tunnel.txt?ts=' + Date.now()).then(r => r.text());
         const m = txt.match(/PUBLIC_URL=(https:\/\/[-\w.]+\.trycloudflare\.com)/);
         if (m) {
-          const url = m[1] + "/upload-ui";
-          document.getElementById("qr").src =
-            "https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=" + encodeURIComponent(url);
+          const url = m[1] + '/upload-ui';
+          document.getElementById('qr').src =
+            'https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=' + encodeURIComponent(url);
+          return;
         }
-      });
+      } catch(e){}
+      setTimeout(loadQR, 1000);
+    }
+    loadQR();
     function check() {
       fetch("/status").then(r=>r.json()).then(j=>{
         if(j.uploaded) window.location.href="/trim-ui";

--- a/start_pod.bat
+++ b/start_pod.bat
@@ -39,6 +39,12 @@ if not exist "%BASE%trimmed.mp3" (
     timeout /t 1 >nul
     goto waitTrimmed
 )
+for %%I in ("%BASE%trimmed.mp3") do set "SIZE=%%~zI"
+if "%SIZE%"=="0" (
+    echo . waiting for write completion...
+    timeout /t 1 >nul
+    goto waitTrimmed
+)
 
 echo.
 echo [6/9] Converting trimmed.mp3 → Song.wav...


### PR DESCRIPTION
## Summary
- wait until Cloudflare tunnel is ready before showing QR code
- ensure uploads only mark as complete when done
- use configured ffmpeg path and check for errors when trimming
- make batch script wait for non-empty trimmed file before converting
- fix QR code polling by adding a cache-busting parameter

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_684e408536e88331b279a30f4cc20919